### PR TITLE
Coordinates fix for LK Kassel

### DIFF
--- a/ags.json
+++ b/ags.json
@@ -836,8 +836,8 @@
   "6633": {
     "name": "LK Kassel",
     "state": "Hessen",
-    "lat": 51.3169,
-    "lon": 9.4925
+    "lat": 51.4142,
+    "lon": 9.1471
   },
   "6634": {
     "name": "LK Schwalm-Eder-Kreis",


### PR DESCRIPTION
`LK Kassel` and `SK Kassel` had the same coordinates. Leads to overlaps in visualizations.
Source: Manual check on Google Maps