### PR TITLE
rki data: consolidate Aachen correction

### DIFF
--- a/tools/build-rki-csvs.py
+++ b/tools/build-rki-csvs.py
@@ -345,10 +345,13 @@ def fetch_lks():
         # 201204-12:22:25.662 INFO: fetch LK-resolved RKI data from arcgis system
         # 201204-12:22:25.662 INFO: Query for set of LKs
         # {'IdLandkreis': '05354', 'Landkreis': 'LK Aachen', 'Bundesland': 'Nordrhein-Westfalen', 'ObjectId': 28250}
-        if o["Landkreis"] == "LK Aachen":
+        # {'IdLandkreis': '05354', 'Landkreis': 'StadtRegion Aachen', 'Bundesland': 'Nordrhein-Westfalen', 'ObjectId': 29327}
+        # AGS 05354 was "Kreis Aachen". Until 2009. Since then 5334 Städteregion Aachen.
+        if "Aachen" in o["Landkreis"] and int(o["IdLandkreis"]) == 5354:
             if o["IdLandkreis"] != "05334":
                 log.info(
-                    "unexpected AGS for LK Aachen in ArcGIS: %s -- heal",
+                    "unexpected AGS for %s Aachen in ArcGIS: %s -- correct: 5334",
+                    o,
                     o["IdLandkreis"],
                 )
                 o["IdLandkreis"] = "05334"


### PR DESCRIPTION
Now they renamed `LK Aachen` to `StadtRegion Aachen` but still use the out-dated AGS. We can deal with that.

Aachen's AGS is 5334.

Also see https://de.wikipedia.org/wiki/Aachen and https://www.riserid.eu/data/user_upload/downloads/info-pdf.s/Diverses/Liste-Amtlicher-Gemeindeschluessel-AGS-2015.pdf.



